### PR TITLE
Ensure mount path starts with "/exports/"

### DIFF
--- a/run-mountd.sh
+++ b/run-mountd.sh
@@ -3,7 +3,7 @@
 set -eu
 
 for mnt in "$@"; do
-  if [[ ! "$mnt" =~ "/exports/" ]]; then
+  if [[ ! "$mnt" =~ ^/exports/ ]]; then
     >&2 echo "Path to NFS export must be inside of the \"/exports/\" directory"
     exit 1
   fi


### PR DESCRIPTION
The previous expression would match if "/exports/" appear anywhere in "$mnt".

```
$ [[ "bar/exports/foo" =~ "/exports/" ]]; echo $?
0
```
